### PR TITLE
Disable 1-3 Rev Strat pattern (v0.0.1a8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thestrat"
-version = "0.0.1a7"
+version = "0.0.1a8"
 description = "#TheStrat indicators and timeframe aggregation for financial market data"
 authors = [
     {name = "Jason Lixfeld", email = "nominal_choroid0y@icloud.com"}

--- a/thestrat/signals.py
+++ b/thestrat/signals.py
@@ -163,15 +163,15 @@ SIGNALS = {
         "description": "Context reversal - 3-2D with opposite continuity",
     },
     # Special Rev Strat signals
-    "1-3": {
-        "category": "reversal",
-        "bias": None,  # Determined by 1-bar type
-        "bar_count": 2,
-        "entry_bar_offset": 0,
-        "trigger_bar_offset": 1,
-        "target_bar_offset": 2,  # Requires 3rd bar for target
-        "description": "1-bar Rev Strat signal",
-    },
+    # "1-3": {
+    #     "category": "reversal",
+    #     "bias": None,  # Determined by 1-bar type
+    #     "bar_count": 2,
+    #     "entry_bar_offset": 0,
+    #     "trigger_bar_offset": 1,
+    #     "target_bar_offset": 2,  # Requires 3rd bar for target
+    #     "description": "1-bar Rev Strat signal",
+    # },
 }
 
 

--- a/thestrat/signals.py
+++ b/thestrat/signals.py
@@ -163,7 +163,7 @@ SIGNALS = {
         "description": "Context reversal - 3-2D with opposite continuity",
     },
     # Special Rev Strat signals
-    # "1-3": {
+    # "1-3": {  # too complex to implement properly. Can be inferred by looking for inside bar followed by a gapping directional 2 that changes continuity before the low (or high) of the inside bar
     #     "category": "reversal",
     #     "bias": None,  # Determined by 1-bar type
     #     "bar_count": 2,

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "thestrat"
-version = "0.0.1a7"
+version = "0.0.1a8"
 source = { editable = "." }
 dependencies = [
     { name = "coverage", extra = ["toml"] },

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "thestrat"
-version = "0.0.1a6"
+version = "0.0.1a7"
 source = { editable = "." }
 dependencies = [
     { name = "coverage", extra = ["toml"] },


### PR DESCRIPTION
## Summary

This PR disables the 1-3 Rev Strat pattern by commenting out its definition in the signals dictionary.

## Changes Made

- **signals.py**: Commented out the  signal definition (lines 166-174)
- **pyproject.toml**: Bumped version from  to 
- **uv.lock**: Updated lock file

## Impact

⚠️ **BREAKING CHANGE**: This is a breaking change that removes functionality.

- The 1-3 Rev Strat pattern will no longer be detected by the signal detection system
- Any existing code that relied on the 1-3 pattern being available will need to be updated
- All tests continue to pass (254 passed, 5 skipped)

## Testing

- ✅ Full test suite passes
- ✅ No tests were dependent on the 1-3 pattern
- ✅ Pre-commit hooks pass
- ✅ All linting and formatting checks pass

## Version

Version bumped to  following semantic versioning for alpha releases.