### PR TITLE
fix: resolve target_prices population failure due to variable shadowing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thestrat"
-version = "0.0.1a16"
+version = "0.0.1a17"
 description = "#TheStrat indicators and timeframe aggregation for financial market data"
 authors = [
     {name = "Jason Lixfeld", email = "nominal_choroid0y@icloud.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "thestrat"
-version = "0.0.1a15"
+version = "0.0.1a17"
 source = { editable = "." }
 dependencies = [
     { name = "coverage", extra = ["toml"] },


### PR DESCRIPTION
## Summary
Fixes critical bug where `target_prices` and `target_count` remained NULL for all signals despite proper configuration and sufficient historical data.

## Root Cause
Variable shadowing in `_calculate_signals()` caused the `TimeframeItemConfig` parameter to be overwritten with signal metadata dict from the `SIGNALS` loop iteration variable.

## Changes

### Primary Fix: Variable Shadowing
- **Lines 551, 559**: Renamed loop variable from `config` to `signal_config`
- Prevents `TimeframeItemConfig` from being overwritten
- Allows `target_config` to flow correctly to `_populate_targets_in_dataframe()`

### Secondary Fixes
- **Line 853**: Changed `== True` to `.is_not_null()` for float column filtering
- **Line 790**: Added existence check before adding `__row_idx` column
- **Line 859**: Fixed DataFrame row extraction using `.row()` method

### Test Improvements
- Converted conditional assertions to required assertions
- Test now properly fails when targets aren't populated
- Clear error messages for debugging

## Impact
- **Before**: target_prices NULL for 100% of signals (0/90)
- **After**: target_prices populated for 98.9% of signals (179/181)
- **Multiple targets**: 26.8% of signals have 2-10 targets
- **Max targets found**: 10 targets per signal

## Testing
- ✅ All 314 unit tests pass
- ✅ All 6 eager target evaluation tests pass
- ✅ Target ordering verified (ascending for long, descending for short)
- ✅ `max_targets` parameter respected
- ✅ Tested with 100-200 bar datasets
- ✅ Verified with multiple `max_targets` settings (1, 3, 5, 10)

## Example
Signal with 10 targets:
```
Pattern: 2U-2D (short reversal)
Close: $122.80
Target Prices: [121.52, 115.34, 113.41, 111.32, 108.47, 108.37, 
                107.00, 103.39, 101.69, 100.10]
Order: ✅ Descending (highest to lowest)
```

## Version
Bumps version from 0.0.1a16 to 0.0.1a17

Closes issue reported by integrator regarding non-functional eager target evaluation feature.