### PR TITLE
fix: correct target detection with trigger filtering and structural bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thestrat"
-version = "0.0.1a18"
+version = "0.0.1a19"
 description = "#TheStrat indicators and timeframe aggregation for financial market data"
 authors = [
     {name = "Jason Lixfeld", email = "nominal_choroid0y@icloud.com"}


### PR DESCRIPTION
## Summary

Fixes two critical bugs in target detection that caused incomplete and incorrect target ladders for signals.

### Bug #1: Incorrect bound extraction
**Issue**: `_detect_targets_for_signal()` extracted bound price from bar's OHLC column (`target_col`) instead of structural level (`structure_col`).

**Impact**: Structural bounds like `higher_high` (519.3) were replaced with bar's high (513.94), causing missing targets.

**Fix**: Changed line 836 to extract from `structure_col` (forward-filled structural level).

### Bug #2: Missing trigger bar filtering
**Issue**: No validation that first target exceeded trigger bar's price level.

**Impact**: Invalid targets included in ladders (e.g., targets below trigger for short signals).

**Fix**: Added trigger price filtering (lines 792-822):
- Saves trigger bar's price (i=0 in reversed list)
- Only accepts first target if beyond trigger (> for long, < for short)
- Continues building ladder with proper ascending/descending logic

## Test Coverage

Added 4 comprehensive tests to `TestTargetDetection` class using real MSFT data:
- `test_msft_long_signal_with_real_higher_high_bound` - Validates 4-target ascending ladder
- `test_msft_short_signal_with_real_lower_low_bound` - Validates 6-target descending ladder
- `test_trigger_filtering_excludes_invalid_long_targets` - Ensures targets below trigger excluded
- `test_trigger_filtering_excludes_invalid_short_targets` - Ensures targets above trigger excluded

All 325 tests passing (321 existing + 4 new).

## Validation

**MSFT 09-26 2D-2U long reversal**:
- Before: [512.48]
- After: [512.48, 514.59, 517.74, 519.3] ✅

**MSFT 09-25 2D-2D short continuation**:
- Before: [507.31, 505.93]
- After: [505.93, 503.85, 497.88, 496.72, 495.03, 492.37] ✅