### PR TITLE
fix: aggregator supports '1d' timeframe (1.0.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thestrat"
-version = "1.0.0"
+version = "1.0.1"
 description = "Vectorized OHLCV timeframe aggregation and Strat bar classification (Polars)"
 authors = [
     {name = "Jason Lixfeld", email = "nominal_choroid0y@icloud.com"}

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -24,6 +24,72 @@ def _make_daily_bars(days: list[tuple]) -> pl.DataFrame:
     )
 
 
+def test_aggregate_daily_from_intraday():
+    """Aggregates intraday bars into daily bars (UTC midnight-aligned)."""
+    # Two days, three intraday bars each
+    bars = pl.DataFrame(
+        [
+            {
+                "timestamp": datetime(2026, 4, 7, 13, 30, tzinfo=UTC),
+                "open": 100.0,
+                "high": 102.0,
+                "low": 99.0,
+                "close": 101.0,
+                "volume": 100.0,
+            },
+            {
+                "timestamp": datetime(2026, 4, 7, 18, 0, tzinfo=UTC),
+                "open": 101.0,
+                "high": 105.0,
+                "low": 100.0,
+                "close": 104.0,
+                "volume": 200.0,
+            },
+            {
+                "timestamp": datetime(2026, 4, 7, 19, 59, tzinfo=UTC),
+                "open": 104.0,
+                "high": 106.0,
+                "low": 103.0,
+                "close": 105.0,
+                "volume": 150.0,
+            },
+            {
+                "timestamp": datetime(2026, 4, 8, 13, 30, tzinfo=UTC),
+                "open": 105.5,
+                "high": 107.0,
+                "low": 104.0,
+                "close": 106.0,
+                "volume": 120.0,
+            },
+            {
+                "timestamp": datetime(2026, 4, 8, 18, 0, tzinfo=UTC),
+                "open": 106.0,
+                "high": 108.0,
+                "low": 105.0,
+                "close": 107.5,
+                "volume": 180.0,
+            },
+        ]
+    )
+    agg = TimeframeAggregator()
+    result = agg.aggregate(bars, "1d").sort("timestamp")
+
+    assert len(result) == 2
+    day1 = result.row(0, named=True)
+    assert day1["open"] == 100.0
+    assert day1["high"] == 106.0
+    assert day1["low"] == 99.0
+    assert day1["close"] == 105.0
+    assert day1["volume"] == 450.0
+
+    day2 = result.row(1, named=True)
+    assert day2["open"] == 105.5
+    assert day2["high"] == 108.0
+    assert day2["low"] == 104.0
+    assert day2["close"] == 107.5
+    assert day2["volume"] == 300.0
+
+
 def test_aggregate_weekly():
     """Aggregates daily bars into weekly bars (Monday-aligned)."""
     bars = _make_daily_bars(

--- a/thestrat/aggregator.py
+++ b/thestrat/aggregator.py
@@ -63,7 +63,9 @@ class TimeframeAggregator:
             return ts.dt.truncate(duration)
 
         # Daily+ — calendar-based
-        if timeframe == "1w":
+        if timeframe == "1d":
+            return ts.dt.truncate("1d")
+        elif timeframe == "1w":
             return ts.dt.truncate("1w")
         elif timeframe == "1m":
             return ts.dt.truncate("1mo")

--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ wheels = [
 
 [[package]]
 name = "thestrat"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "polars", extra = ["timezone"] },


### PR DESCRIPTION
## Summary
1.0.0 shipped `Timeframe.ONE_DAY = \"1d\"` in the enum but `_group_expression` has no branch for it, so `aggregate(bars, \"1d\")` raises `ValueError: Unsupported aggregation timeframe: 1d`. StratTraderMCP never hit this because its callers passed already-aggregated daily bars in. StratBacktester's per-instrument 1m → 1d path surfaces it immediately.

Closes #60.

## Change
- Add `if timeframe == \"1d\": return ts.dt.truncate(\"1d\")` to the daily+ block in `aggregator.py`
- Add `test_aggregate_daily_from_intraday` regression test (5 intraday bars across 2 days → 2 daily bars with verified OHLCV semantics)
- Bump version `1.0.0` → `1.0.1`

## Test plan
- [x] `uv run pytest` — 79 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)