### PR TITLE
feat: InstrumentType + Session for hour-and-above timeframe alignment (1.1.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thestrat"
-version = "1.0.1"
+version = "1.1.0"
 description = "Vectorized OHLCV timeframe aggregation and Strat bar classification (Polars)"
 authors = [
     {name = "Jason Lixfeld", email = "nominal_choroid0y@icloud.com"}

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,411 @@
+"""Tests for InstrumentType / Session presets and session-aware aggregation."""
+
+from datetime import UTC, datetime
+
+import polars as pl
+import pytest
+
+from thestrat import (
+    SESSIONS,
+    InstrumentType,
+    Session,
+    TimeframeAggregator,
+    session_for,
+)
+
+# ---------------------------------------------------------------------------
+# Presets
+# ---------------------------------------------------------------------------
+
+
+def test_all_instrument_types_have_presets():
+    assert set(SESSIONS.keys()) == set(InstrumentType)
+
+
+@pytest.mark.parametrize(
+    "kind,tz,minutes",
+    [
+        (InstrumentType.EQUITY_US, "America/New_York", 570),  # 9:30 ET
+        (InstrumentType.FUTURES_CME, "America/New_York", 1080),  # 18:00 ET
+        (InstrumentType.CRYPTO, "UTC", 0),
+        (InstrumentType.FX, "America/New_York", 1020),  # 17:00 ET
+    ],
+)
+def test_session_for_returns_canonical_preset(kind, tz, minutes):
+    s = session_for(kind)
+    assert s.timezone == tz
+    assert s.anchor_minutes == minutes
+
+
+# ---------------------------------------------------------------------------
+# Session-aware daily aggregation
+# ---------------------------------------------------------------------------
+
+
+def _utc(year, month, day, hour=0, minute=0):
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+def test_daily_with_futures_cme_session_aligns_to_18_et():
+    # CME futures session start is 18:00 ET = 22:00 UTC (during DST that's 23:00 UTC).
+    # In June 2026 NY is on EDT, so 18:00 ET = 22:00 UTC.
+    # A bar at 22:00 UTC on Sun should belong to Mon's session.
+    bars = pl.DataFrame(
+        [
+            # Sun June 7 22:00 UTC = Sun June 7 18:00 EDT — session starts (Mon's session)
+            {
+                "timestamp": _utc(2026, 6, 7, 22, 0),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 100,
+            },
+            # Mon June 8 03:00 UTC = Sun 23:00 EDT — same session as above
+            {
+                "timestamp": _utc(2026, 6, 8, 3, 0),
+                "open": 100.5,
+                "high": 102.0,
+                "low": 100.0,
+                "close": 101.5,
+                "volume": 200,
+            },
+            # Mon June 8 21:00 UTC = Mon 17:00 EDT — last bar of Mon's session
+            {
+                "timestamp": _utc(2026, 6, 8, 21, 0),
+                "open": 101.5,
+                "high": 103.0,
+                "low": 101.0,
+                "close": 102.5,
+                "volume": 300,
+            },
+            # Mon June 8 22:00 UTC = Mon 18:00 EDT — session starts (Tue's session)
+            {
+                "timestamp": _utc(2026, 6, 8, 22, 0),
+                "open": 102.5,
+                "high": 104.0,
+                "low": 102.0,
+                "close": 103.5,
+                "volume": 150,
+            },
+            # Tue June 9 02:00 UTC = Mon 22:00 EDT — same session as above (Tue)
+            {
+                "timestamp": _utc(2026, 6, 9, 2, 0),
+                "open": 103.5,
+                "high": 105.0,
+                "low": 103.0,
+                "close": 104.0,
+                "volume": 250,
+            },
+        ]
+    )
+    agg = TimeframeAggregator()
+    result = agg.aggregate(bars, "1d", session=SESSIONS[InstrumentType.FUTURES_CME]).sort("timestamp")
+
+    # Expect 2 daily bars (Mon's session and Tue's session), not 3 from UTC midnight split
+    assert len(result) == 2
+
+    mon = result.row(0, named=True)
+    tue = result.row(1, named=True)
+    # Mon's session: open of first bar 100.0, close of last bar 102.5,
+    # high = max of first 3 bars, low = min of first 3 bars, vol = sum
+    assert mon["open"] == 100.0
+    assert mon["high"] == 103.0
+    assert mon["low"] == 99.0
+    assert mon["close"] == 102.5
+    assert mon["volume"] == 600
+    # Tue's session: open 102.5 (the 22:00 UTC bar), close 104.0, vol = 400
+    assert tue["open"] == 102.5
+    assert tue["close"] == 104.0
+    assert tue["volume"] == 400
+
+
+def test_daily_with_equity_us_session_aligns_to_9_30_et():
+    # Equity US daily anchor is 9:30 ET. June 8 9:30 EDT = June 8 13:30 UTC.
+    # All bars in 13:30 UTC → next day 13:29 UTC are one daily bar.
+    bars = pl.DataFrame(
+        [
+            # Mon 13:30 UTC = Mon 9:30 EDT — session starts (Mon's day)
+            {
+                "timestamp": _utc(2026, 6, 8, 13, 30),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 100,
+            },
+            # Mon 20:00 UTC = Mon 16:00 EDT — close of Mon's RTH
+            {
+                "timestamp": _utc(2026, 6, 8, 20, 0),
+                "open": 100.5,
+                "high": 102.0,
+                "low": 100.0,
+                "close": 101.5,
+                "volume": 200,
+            },
+            # Tue 13:30 UTC = Tue 9:30 EDT — Tue's day starts
+            {
+                "timestamp": _utc(2026, 6, 9, 13, 30),
+                "open": 101.5,
+                "high": 103.0,
+                "low": 101.0,
+                "close": 102.5,
+                "volume": 150,
+            },
+        ]
+    )
+    agg = TimeframeAggregator()
+    result = agg.aggregate(bars, "1d", session=SESSIONS[InstrumentType.EQUITY_US]).sort("timestamp")
+
+    assert len(result) == 2
+
+
+def test_hourly_with_equity_us_session_aligns_to_30():
+    # 60-min "Bottom of the Hour" buckets at 9:30, 10:30, 11:30 ET.
+    # Mon 13:30 UTC = 9:30 EDT
+    bars = pl.DataFrame(
+        [
+            {
+                "timestamp": _utc(2026, 6, 8, 13, 30),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.5,
+                "close": 100.5,
+                "volume": 100,
+            },
+            {
+                "timestamp": _utc(2026, 6, 8, 14, 0),
+                "open": 100.5,
+                "high": 101.5,
+                "low": 100.0,
+                "close": 101.0,
+                "volume": 100,
+            },
+            {
+                "timestamp": _utc(2026, 6, 8, 14, 29),
+                "open": 101.0,
+                "high": 101.6,
+                "low": 100.8,
+                "close": 101.4,
+                "volume": 100,
+            },
+            # 14:30 UTC = 10:30 EDT — new bucket
+            {
+                "timestamp": _utc(2026, 6, 8, 14, 30),
+                "open": 101.4,
+                "high": 102.0,
+                "low": 101.3,
+                "close": 101.8,
+                "volume": 100,
+            },
+            {
+                "timestamp": _utc(2026, 6, 8, 15, 0),
+                "open": 101.8,
+                "high": 102.5,
+                "low": 101.5,
+                "close": 102.0,
+                "volume": 100,
+            },
+        ]
+    )
+    agg = TimeframeAggregator()
+    result = agg.aggregate(bars, "1h", session=SESSIONS[InstrumentType.EQUITY_US]).sort("timestamp")
+
+    assert len(result) == 2
+    first, second = result.row(0, named=True), result.row(1, named=True)
+    # First bucket: 9:30-10:30 — contains the first 3 bars
+    assert first["open"] == 100.0
+    assert first["close"] == 101.4
+    assert first["high"] == 101.6
+    # Second bucket: 10:30-11:30 — contains the last 2 bars
+    assert second["open"] == 101.4
+    assert second["close"] == 102.0
+
+
+def test_session_handles_dst_transition():
+    # Spring-forward in NY is 2nd Sunday of March. In 2026 that's Mar 8.
+    # Before Mar 8 NY is EST (UTC-5), after is EDT (UTC-4).
+    # 18:00 EST Mar 6 = 23:00 UTC; 18:00 EDT Mar 9 = 22:00 UTC.
+    # The session anchor MUST follow local 18:00, not a fixed UTC offset.
+    bars = pl.DataFrame(
+        [
+            # Fri Mar 6 18:00 EST = 23:00 UTC. Start of Mar 9 session (Mon).
+            {
+                "timestamp": _utc(2026, 3, 6, 23, 0),
+                "open": 100.0,
+                "high": 100.5,
+                "low": 99.5,
+                "close": 100.2,
+                "volume": 100,
+            },
+            # Mon Mar 9 18:00 EDT = 22:00 UTC. Start of Tue session.
+            {
+                "timestamp": _utc(2026, 3, 9, 22, 0),
+                "open": 101.0,
+                "high": 101.5,
+                "low": 100.5,
+                "close": 101.2,
+                "volume": 100,
+            },
+        ]
+    )
+    agg = TimeframeAggregator()
+    result = agg.aggregate(bars, "1d", session=SESSIONS[InstrumentType.FUTURES_CME])
+
+    # Two distinct sessions, anchored at LOCAL 18:00 ET — DST handled.
+    assert len(result) == 2
+
+
+def test_aggregate_for_instrument_convenience():
+    bars = pl.DataFrame(
+        [
+            {
+                "timestamp": _utc(2026, 6, 7, 22, 0),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 100,
+            },
+            {
+                "timestamp": _utc(2026, 6, 8, 21, 0),
+                "open": 100.5,
+                "high": 103.0,
+                "low": 100.0,
+                "close": 102.5,
+                "volume": 300,
+            },
+            {
+                "timestamp": _utc(2026, 6, 8, 22, 0),
+                "open": 102.5,
+                "high": 104.0,
+                "low": 102.0,
+                "close": 103.5,
+                "volume": 150,
+            },
+        ]
+    )
+    agg = TimeframeAggregator()
+
+    explicit = agg.aggregate(bars, "1d", session=SESSIONS[InstrumentType.FUTURES_CME]).sort("timestamp")
+    convenience = agg.aggregate_for_instrument(bars, "1d", InstrumentType.FUTURES_CME).sort("timestamp")
+
+    assert explicit.equals(convenience)
+
+
+# ---------------------------------------------------------------------------
+# Naive timestamps (the StratBacktester DuckDB case)
+# ---------------------------------------------------------------------------
+
+
+def test_session_aware_works_on_naive_timestamps():
+    """DuckDB returns naive timestamps that are logically UTC. Aggregator
+    should handle that without forcing the caller to add a timezone."""
+    bars = pl.DataFrame(
+        [
+            {
+                "timestamp": datetime(2026, 6, 7, 22, 0),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 100,
+            },
+            {
+                "timestamp": datetime(2026, 6, 8, 21, 0),
+                "open": 100.5,
+                "high": 103.0,
+                "low": 100.0,
+                "close": 102.5,
+                "volume": 300,
+            },
+            {
+                "timestamp": datetime(2026, 6, 8, 22, 0),
+                "open": 102.5,
+                "high": 104.0,
+                "low": 102.0,
+                "close": 103.5,
+                "volume": 150,
+            },
+        ]
+    )
+    ts_dtype = bars.schema["timestamp"]
+    assert isinstance(ts_dtype, pl.Datetime) and ts_dtype.time_zone is None  # naive
+
+    agg = TimeframeAggregator()
+    result = agg.aggregate(bars, "1d", session=SESSIONS[InstrumentType.FUTURES_CME]).sort("timestamp")
+
+    # Two sessions
+    assert len(result) == 2
+    # Output timestamp stays naive (matches input shape)
+    out_dtype = result.schema["timestamp"]
+    assert isinstance(out_dtype, pl.Datetime) and out_dtype.time_zone is None
+
+
+# ---------------------------------------------------------------------------
+# Session is a frozen dataclass — equality + immutability
+# ---------------------------------------------------------------------------
+
+
+def test_session_is_frozen():
+    s = Session(timezone="UTC", anchor_minutes=0)
+    with pytest.raises((AttributeError, Exception)):
+        s.anchor_minutes = 100  # type: ignore[misc]
+
+
+def test_session_equality():
+    a = Session(timezone="UTC", anchor_minutes=0)
+    b = Session(timezone="UTC", anchor_minutes=0)
+    c = Session(timezone="UTC", anchor_minutes=60)
+    assert a == b
+    assert a != c
+
+
+# ---------------------------------------------------------------------------
+# Backward compat: legacy equity_offset still works
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_equity_offset_still_aligns_hourly_to_30():
+    bars = pl.DataFrame(
+        [
+            {
+                "timestamp": _utc(2026, 6, 8, 13, 30),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.5,
+                "close": 100.5,
+                "volume": 100,
+            },
+            {
+                "timestamp": _utc(2026, 6, 8, 14, 30),
+                "open": 100.5,
+                "high": 102.0,
+                "low": 100.0,
+                "close": 101.5,
+                "volume": 100,
+            },
+        ]
+    )
+    agg = TimeframeAggregator()
+    result = agg.aggregate(bars, "1h", equity_offset=True).sort("timestamp")
+    # Each bar lands in its own 9:30/10:30 bucket
+    assert len(result) == 2
+
+
+def test_unsupported_timeframe_raises():
+    bars = pl.DataFrame(
+        [
+            {
+                "timestamp": _utc(2026, 6, 8, 13, 30),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.5,
+                "close": 100.5,
+                "volume": 100,
+            },
+        ]
+    )
+    agg = TimeframeAggregator()
+    with pytest.raises(ValueError, match="Unsupported aggregation timeframe"):
+        agg.aggregate(bars, "7min")

--- a/thestrat/__init__.py
+++ b/thestrat/__init__.py
@@ -17,6 +17,7 @@ from thestrat.classifier import (
     classify_color,
     classify_scenario,
 )
+from thestrat.sessions import SESSIONS, InstrumentType, Session, session_for
 from thestrat.types import (
     BarDict,
     ClassifiedBar,
@@ -46,5 +47,9 @@ __all__ = [
     "Scenario",
     "Shape",
     "Timeframe",
+    "Session",
+    "InstrumentType",
+    "SESSIONS",
+    "session_for",
     "__version__",
 ]

--- a/thestrat/aggregator.py
+++ b/thestrat/aggregator.py
@@ -1,31 +1,89 @@
-"""Polars-based timeframe aggregation for OHLCV bars."""
+"""Polars-based timeframe aggregation for OHLCV bars.
+
+Hour-and-above timeframes (1h, 4h, 6h, 12h, 1d, 1w, 1m, 1q, 1y) can be
+aligned to a `Session` (timezone + anchor offset) via the `session`
+parameter, so that buckets line up with the relevant trading day's open
+instead of UTC midnight.
+"""
+
+from __future__ import annotations
 
 import polars as pl
 
-# Offset for equity hour-based aggregations: US equity markets open at 9:30 ET,
-# so hour boundaries (10:30, 11:30, ...) align with the 30-minute offset.
+from thestrat.sessions import SESSIONS, InstrumentType, Session
+
+# Legacy: 30-minute offset for equity hour-based buckets aligned to 9:30 ET.
+# `equity_offset=True` is now equivalent to `session=SESSIONS[EQUITY_US]`,
+# kept for backward compat.
 EQUITY_OFFSET_MINUTES = 30
+
+_HOUR_BASED = {"1h", "4h", "6h", "12h"}
+_DAILY_PLUS = {"1d", "1w", "1m", "1q", "1y"}
+_TRUNC_UNIT = {
+    "1min": "1m",
+    "5min": "5m",
+    "15min": "15m",
+    "30min": "30m",
+    "1h": "1h",
+    "4h": "4h",
+    "6h": "6h",
+    "12h": "12h",
+    "1d": "1d",
+    "1w": "1w",
+    "1m": "1mo",  # calendar month, not 1-minute
+    "1q": "1q",
+    "1y": "1y",
+}
 
 
 class TimeframeAggregator:
     """Aggregates raw OHLCV bars into higher timeframes using Polars."""
 
-    def aggregate(self, bars: pl.DataFrame, timeframe: str, equity_offset: bool = False) -> pl.DataFrame:
+    def aggregate(
+        self,
+        bars: pl.DataFrame,
+        timeframe: str,
+        equity_offset: bool = False,
+        *,
+        session: Session | None = None,
+    ) -> pl.DataFrame:
         """Aggregate bars to the given timeframe.
 
         Args:
-            bars: DataFrame with columns: timestamp, open, high, low, close, volume.
-            timeframe: Target timeframe.
-            equity_offset: If True, offset hour-based timeframes by 30 minutes
-                          (for equities opening at :30). Only affects 1h, 4h, 6h, 12h.
+            bars: DataFrame with columns timestamp, open, high, low, close, volume.
+                Timestamp may be naive (assumed UTC) or timezone-aware.
+            timeframe: Target timeframe ("5min", "1h", "1d", ...).
+            equity_offset: Legacy. If True and `session` is None, applies a
+                30-minute offset to hour-based buckets only (9:30 ET equity
+                open). Equivalent to passing `session=SESSIONS[EQUITY_US]`
+                but only affects hour-based, not daily+. Prefer `session`.
+            session: Session preset (timezone + anchor minutes). When given,
+                all hour-and-above timeframes are aligned to this anchor.
+                Sub-hour timeframes (1min, 5min, 15min, 30min) are unaffected.
+
+        Returns:
+            Aggregated DataFrame with the same columns. Timestamps in the
+            output are in the same form as the input — naive bars yield
+            naive output, aware bars yield aware output (in their original
+            timezone).
         """
         if bars.is_empty():
             return bars
 
-        bars = bars.sort("timestamp")
-        group_expr = self._group_expression(timeframe, equity_offset)
+        if timeframe not in _TRUNC_UNIT:
+            raise ValueError(f"Unsupported aggregation timeframe: {timeframe}")
 
-        return (
+        bars = bars.sort("timestamp")
+        ts_dtype = bars.schema["timestamp"]
+        input_was_naive = isinstance(ts_dtype, pl.Datetime) and ts_dtype.time_zone is None
+
+        # Mark naive timestamps as UTC so timezone math is well-defined.
+        if input_was_naive:
+            bars = bars.with_columns(pl.col("timestamp").dt.replace_time_zone("UTC"))
+
+        group_expr = self._group_expression(timeframe, equity_offset, session)
+
+        result = (
             bars.with_columns(group_expr.alias("_group"))
             .group_by("_group")
             .agg(
@@ -40,38 +98,48 @@ class TimeframeAggregator:
             .sort("timestamp")
         )
 
-    def _group_expression(self, timeframe: str, equity_offset: bool) -> pl.Expr:
+        # Restore naive timestamps if input was naive.
+        if input_was_naive:
+            result = result.with_columns(pl.col("timestamp").dt.replace_time_zone(None))
+
+        return result
+
+    def aggregate_for_instrument(
+        self,
+        bars: pl.DataFrame,
+        timeframe: str,
+        instrument_type: InstrumentType,
+    ) -> pl.DataFrame:
+        """Convenience: look up the canonical Session for an instrument type
+        and aggregate."""
+        return self.aggregate(bars, timeframe, session=SESSIONS[instrument_type])
+
+    def _group_expression(
+        self,
+        timeframe: str,
+        equity_offset: bool,
+        session: Session | None,
+    ) -> pl.Expr:
         """Return a Polars expression that groups timestamps by timeframe."""
         ts = pl.col("timestamp")
+        unit = _TRUNC_UNIT[timeframe]
 
-        # Intraday — simple truncation (no offset needed for sub-hour)
-        if timeframe == "1min":
-            return ts.dt.truncate("1m")
-        elif timeframe == "5min":
-            return ts.dt.truncate("5m")
-        elif timeframe == "15min":
-            return ts.dt.truncate("15m")
-        elif timeframe == "30min":
-            return ts.dt.truncate("30m")
+        # Sub-hour: simple truncation, never session-aligned.
+        if timeframe in ("1min", "5min", "15min", "30min"):
+            return ts.dt.truncate(unit)
 
-        # Hour-based — may need equity offset
-        if timeframe in ("1h", "4h", "6h", "12h"):
-            duration = {"1h": "1h", "4h": "4h", "6h": "6h", "12h": "12h"}[timeframe]
+        # Session-aware path (preferred): aligns hour+ buckets to session anchor.
+        if session is not None and (timeframe in _HOUR_BASED or timeframe in _DAILY_PLUS):
+            offset = pl.duration(minutes=session.anchor_minutes)
+            ts_local = ts.dt.convert_time_zone(session.timezone)
+            return ((ts_local - offset).dt.truncate(unit) + offset).dt.convert_time_zone("UTC")
+
+        # Legacy `equity_offset` path: 30-min shift for hour-based only.
+        if timeframe in _HOUR_BASED:
             if equity_offset:
                 offset = pl.duration(minutes=EQUITY_OFFSET_MINUTES)
-                return (ts - offset).dt.truncate(duration) + offset
-            return ts.dt.truncate(duration)
+                return (ts - offset).dt.truncate(unit) + offset
+            return ts.dt.truncate(unit)
 
-        # Daily+ — calendar-based
-        if timeframe == "1d":
-            return ts.dt.truncate("1d")
-        elif timeframe == "1w":
-            return ts.dt.truncate("1w")
-        elif timeframe == "1m":
-            return ts.dt.truncate("1mo")
-        elif timeframe == "1q":
-            return ts.dt.truncate("1q")
-        elif timeframe == "1y":
-            return ts.dt.truncate("1y")
-
-        raise ValueError(f"Unsupported aggregation timeframe: {timeframe}")
+        # Daily+ without session: UTC-anchored truncation (legacy behavior).
+        return ts.dt.truncate(unit)

--- a/thestrat/sessions.py
+++ b/thestrat/sessions.py
@@ -1,0 +1,63 @@
+"""Instrument-type session presets for timeframe alignment.
+
+Aggregating 1m bars into hour-and-above timeframes only makes sense if
+each "day" starts at the right moment — otherwise daily/weekly/monthly
+buckets split the actual trading session in half.
+
+Each `InstrumentType` resolves to a `Session(timezone, anchor_minutes)`
+where `anchor_minutes` is minutes-since-midnight in `timezone` for the
+day boundary. Hour-and-above buckets (1h, 4h, 6h, 12h, 1d, 1w, 1m, 1q,
+1y) align to that anchor.
+
+Conventions used here come from the Strat methodology and standard
+US market practice:
+
+- **EQUITY_US**: 9:30 ET — the regular session open. Per the
+  StratPlaybookMCP "Bottom of the Hour" concept, hourly buckets at
+  9:30 / 10:30 / ... are preferred because news + open both happen
+  at :30.
+- **FUTURES_CME**: 18:00 ET — Globex Sunday open. Each CME futures
+  trading day runs ~Sunday 18:00 ET → Friday 17:00 ET.
+- **CRYPTO**: 00:00 UTC — 24/7 markets, no real session.
+- **FX**: 17:00 ET — the conventional NY 5pm rollover.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+@dataclass(frozen=True)
+class Session:
+    """Where each "day" starts for a given instrument's market.
+
+    `timezone` is an IANA tz database name (e.g. "America/New_York", "UTC").
+    `anchor_minutes` is minutes-since-midnight in that timezone for the
+    day boundary — e.g. 570 for 9:30 ET, 1080 for 18:00 ET.
+    """
+
+    timezone: str
+    anchor_minutes: int
+
+
+class InstrumentType(StrEnum):
+    """Coarse instrument categories that share session conventions."""
+
+    EQUITY_US = "equity_us"
+    FUTURES_CME = "futures_cme"
+    CRYPTO = "crypto"
+    FX = "fx"
+
+
+SESSIONS: dict[InstrumentType, Session] = {
+    InstrumentType.EQUITY_US: Session(timezone="America/New_York", anchor_minutes=570),
+    InstrumentType.FUTURES_CME: Session(timezone="America/New_York", anchor_minutes=1080),
+    InstrumentType.CRYPTO: Session(timezone="UTC", anchor_minutes=0),
+    InstrumentType.FX: Session(timezone="America/New_York", anchor_minutes=1020),
+}
+
+
+def session_for(instrument_type: InstrumentType) -> Session:
+    """Look up the canonical Session for an InstrumentType."""
+    return SESSIONS[instrument_type]

--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ wheels = [
 
 [[package]]
 name = "thestrat"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "polars", extra = ["timezone"] },


### PR DESCRIPTION
## Summary
Generalizes the legacy `equity_offset=True` flag into a proper `InstrumentType` + `Session` abstraction so all hour-and-above timeframes can align to the right market session — futures CME (18:00 ET), equity (9:30 ET, the StratPlaybookMCP \"Bottom of the Hour 60s\"), crypto (UTC), FX (17:00 ET).

Closes #62.

## Public API additions
- `thestrat.InstrumentType` — `EQUITY_US`, `FUTURES_CME`, `CRYPTO`, `FX`
- `thestrat.Session` — frozen `(timezone, anchor_minutes)` dataclass
- `thestrat.SESSIONS` — preset dict for each InstrumentType
- `thestrat.session_for(instrument_type)` — preset lookup
- `TimeframeAggregator.aggregate(..., session=Session(...))` — opt-in session-aware bucketing
- `TimeframeAggregator.aggregate_for_instrument(bars, tf, instrument_type)` — convenience

## How it works
1. Convert input timestamps to the session timezone (Polars handles DST automatically)
2. Subtract the session's anchor offset
3. Truncate to bucket size
4. Add the offset back
5. Convert back to UTC (output stays naive if input was naive)

Sub-hour timeframes (1min, 5min, 15min, 30min) are unchanged. Legacy `equity_offset=True` still works (only affects hour-based) for backward compat.

## Test highlights
- **DST transition**: spring-forward on 2026-03-08 — same `session=FUTURES_CME` correctly anchors to local 18:00 ET on both sides of the transition (23:00 UTC EST → 22:00 UTC EDT)
- **Naive timestamps**: DuckDB returns naive timestamps that are logically UTC; aggregator handles them and preserves the naive output shape
- **Bottom of the Hour 60s**: `session=EQUITY_US` produces 9:30/10:30/11:30 buckets, matching the Strat methodology convention
- 94 tests total, all passing

## Test plan
- [x] `uv run pytest` — 94 passed (79 prior + 15 new)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)