### PR TITLE
feat: public bucket_key_expr(timeframe, session) free function (1.2.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thestrat"
-version = "1.1.0"
+version = "1.2.0"
 description = "Vectorized OHLCV timeframe aggregation and Strat bar classification (Polars)"
 authors = [
     {name = "Jason Lixfeld", email = "nominal_choroid0y@icloud.com"}

--- a/tests/test_bucket_key_expr.py
+++ b/tests/test_bucket_key_expr.py
@@ -1,0 +1,133 @@
+"""Tests for the public `bucket_key_expr` free function.
+
+`bucket_key_expr(timeframe, session)` is the supported, public form of the
+grouping expression that `TimeframeAggregator` uses internally to assign each
+raw bar to its higher-timeframe "bucket" (the value thestrat groups on and
+calls `_group`). Downstream consumers import it instead of re-implementing the
+session-anchored grouping logic.
+"""
+
+from datetime import UTC, datetime
+
+import polars as pl
+import pytest
+
+from thestrat import SESSIONS, InstrumentType, bucket_key_expr
+from thestrat.aggregator import TimeframeAggregator
+
+
+def _utc(year, month, day, hour=0, minute=0):
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+def _rth_minute_frame():
+    """One RTH equity session (2026-06-08) as 1-minute UTC bars.
+
+    09:30 ET = 13:30 UTC (EDT); 16:00 ET = 20:00 UTC. RTH is [13:30, 20:00),
+    i.e. 390 one-minute bars.
+    """
+    start = _utc(2026, 6, 8, 13, 30)
+    ts_series = pl.datetime_range(
+        start=start,
+        end=_utc(2026, 6, 8, 19, 59),
+        interval="1m",
+        time_zone="UTC",
+        eager=True,
+    )
+    return pl.DataFrame({"timestamp": ts_series}).with_columns(
+        pl.lit(1.0).alias("open"),
+        pl.lit(1.0).alias("high"),
+        pl.lit(1.0).alias("low"),
+        pl.lit(1.0).alias("close"),
+        pl.lit(1).alias("volume"),
+    )
+
+
+def _apply(expr: pl.Expr, frame: pl.DataFrame) -> pl.Series:
+    return frame.with_columns(expr.alias("_group"))["_group"]
+
+
+# ---------------------------------------------------------------------------
+# (d) importable from the package top level
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_key_expr_is_public():
+    import thestrat
+
+    assert hasattr(thestrat, "bucket_key_expr")
+    assert bucket_key_expr in (thestrat.bucket_key_expr,)
+
+
+# ---------------------------------------------------------------------------
+# (a) EQUITY_US hourly anchors to the bottom of the hour (09:30/10:30/.../15:30)
+# ---------------------------------------------------------------------------
+
+
+def test_hourly_equity_us_anchors_to_bottom_of_hour():
+    frame = _rth_minute_frame()
+    groups = _apply(bucket_key_expr("1h", SESSIONS[InstrumentType.EQUITY_US]), frame)
+
+    # 6.5h RTH → seven hourly buckets (the last is the 15:30–16:00 stub).
+    assert groups.n_unique() == 7
+
+    # Every bucket boundary lands on :30 ET, at hours 09..15.
+    et = groups.unique().sort().dt.convert_time_zone("America/New_York")
+    assert et.dt.minute().to_list() == [30] * 7
+    assert et.dt.hour().to_list() == [9, 10, 11, 12, 13, 14, 15]
+
+
+def test_daily_equity_us_anchors_to_930_et():
+    frame = _rth_minute_frame()
+    groups = _apply(bucket_key_expr("1d", SESSIONS[InstrumentType.EQUITY_US]), frame)
+
+    # A single RTH session collapses to one daily bucket anchored at 09:30 ET.
+    assert groups.n_unique() == 1
+    et = groups.unique().dt.convert_time_zone("America/New_York")
+    assert et.dt.hour().to_list() == [9]
+    assert et.dt.minute().to_list() == [30]
+
+
+# ---------------------------------------------------------------------------
+# (b) FUTURES_CME session output matches the pre-refactor private method
+#     row-for-row (parity guard).
+# ---------------------------------------------------------------------------
+
+
+def test_futures_cme_matches_private_group_expression():
+    frame = _rth_minute_frame()
+    session = SESSIONS[InstrumentType.FUTURES_CME]
+    agg = TimeframeAggregator()
+
+    for tf in ("1h", "4h", "1d", "1w"):
+        legacy = _apply(agg._group_expression(tf, False, session), frame)
+        public = _apply(bucket_key_expr(tf, session), frame)
+        assert public.equals(legacy), f"{tf} diverged from _group_expression"
+
+
+def test_no_session_matches_utc_truncation():
+    frame = _rth_minute_frame()
+    for tf in ("1h", "4h", "1d"):
+        no_session = _apply(bucket_key_expr(tf, None), frame)
+        truncated = _apply(pl.col("timestamp").dt.truncate({"1h": "1h", "4h": "4h", "1d": "1d"}[tf]), frame)
+        assert no_session.equals(truncated), f"{tf} no-session path is not plain UTC truncation"
+
+
+def test_sub_hour_ignores_session():
+    """Sub-hour timeframes are never session-aligned — the session arg is inert."""
+    frame = _rth_minute_frame()
+    for tf, unit in (("1min", "1m"), ("5min", "5m"), ("15min", "15m"), ("30min", "30m")):
+        with_session = _apply(bucket_key_expr(tf, SESSIONS[InstrumentType.EQUITY_US]), frame)
+        truncated = _apply(pl.col("timestamp").dt.truncate(unit), frame)
+        assert with_session.equals(truncated), f"{tf} sub-hour bucket is not plain truncation"
+
+
+# ---------------------------------------------------------------------------
+# (c) unknown timeframe raises ValueError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("session", [None, SESSIONS[InstrumentType.EQUITY_US]])
+def test_unknown_timeframe_raises(session):
+    with pytest.raises(ValueError, match="timeframe"):
+        bucket_key_expr("bogus", session)

--- a/tests/test_bucket_key_expr.py
+++ b/tests/test_bucket_key_expr.py
@@ -123,6 +123,78 @@ def test_sub_hour_ignores_session():
 
 
 # ---------------------------------------------------------------------------
+# DST transitions (wall-clock anchoring — regression for the physical-duration
+# misanchor: the Globex Sunday session must not split on a spring-forward date)
+# ---------------------------------------------------------------------------
+
+
+def _minute_frame(start_utc: datetime, end_utc: datetime, interval: str = "1m") -> pl.DataFrame:
+    ts = pl.datetime_range(start=start_utc, end=end_utc, interval=interval, time_zone="UTC", eager=True)
+    return pl.DataFrame({"timestamp": ts})
+
+
+def test_futures_spring_forward_sunday_session_is_one_daily_bucket():
+    """US spring-forward 2025-03-09: the CME session (Sun 18:00 ET -> Mon 17:00 ET)
+    spans the 02:00 transition. Physical-duration arithmetic split its first hour
+    into a Saturday-keyed bucket; wall-clock arithmetic must keep one bucket
+    keyed at the Sunday 18:00 ET open (22:00 UTC, EDT after the transition)."""
+    frame = _minute_frame(_utc(2025, 3, 9, 22, 0), _utc(2025, 3, 10, 20, 59))
+    groups = _apply(bucket_key_expr("1d", SESSIONS[InstrumentType.FUTURES_CME]), frame)
+
+    assert groups.n_unique() == 1
+    assert groups.unique().to_list() == [_utc(2025, 3, 9, 22, 0)]
+
+
+def test_futures_fall_back_sunday_session_keyed_at_open():
+    """US fall-back 2025-11-02: session opens Sun 18:00 EST = 23:00 UTC. The
+    physical-duration arithmetic kept one bucket but keyed it 17:00 ET; the
+    wall-clock key must be the 18:00 ET open."""
+    frame = _minute_frame(_utc(2025, 11, 2, 23, 0), _utc(2025, 11, 3, 21, 59))
+    groups = _apply(bucket_key_expr("1d", SESSIONS[InstrumentType.FUTURES_CME]), frame)
+
+    assert groups.n_unique() == 1
+    assert groups.unique().to_list() == [_utc(2025, 11, 2, 23, 0)]
+
+
+def test_equity_rth_unaffected_by_dst_transitions():
+    """RTH timestamps never cross the 02:00 Sunday transition when shifted by
+    the 570-min anchor: hourly buckets on the Mondays after both 2025
+    transitions still anchor 09:30..15:30 local."""
+    for monday, utc_offset in (((2025, 3, 10), 4), ((2025, 11, 3), 5)):
+        y, m, d = monday
+        frame = _minute_frame(_utc(y, m, d, 9 + utc_offset, 30), _utc(y, m, d, 15 + utc_offset, 59))
+        groups = _apply(bucket_key_expr("1h", SESSIONS[InstrumentType.EQUITY_US]), frame)
+        et = groups.unique().sort().dt.convert_time_zone("America/New_York")
+        assert et.dt.minute().to_list() == [30] * 7, f"{monday}: hourly buckets off :30"
+        assert et.dt.hour().to_list() == [9, 10, 11, 12, 13, 14, 15], f"{monday}: wrong anchors"
+
+
+def test_spring_forward_gap_bucket_key_shifts_past_gap():
+    """A 4h futures bucket key of 02:00 local on a spring-forward date does not
+    exist; it must shift forward to 03:00 EDT (07:00 UTC), not go null or raise."""
+    # Sun 2025-03-09 03:30 / 05:30 EDT (07:30 / 09:30 UTC) — inside the
+    # 02:00-06:00 wall-clock bucket whose nominal key is the non-existent 02:00.
+    frame = _minute_frame(_utc(2025, 3, 9, 7, 30), _utc(2025, 3, 9, 9, 30), interval="2h")
+    groups = _apply(bucket_key_expr("4h", SESSIONS[InstrumentType.FUTURES_CME]), frame)
+
+    assert groups.null_count() == 0
+    assert groups.n_unique() == 1
+    assert groups.unique().to_list() == [_utc(2025, 3, 9, 7, 0)]  # 03:00 EDT
+
+
+def test_fall_back_repeated_hour_merges_into_one_wall_clock_bucket():
+    """On fall-back the 01:00-01:59 local hour occurs twice; wall-clock
+    bucketing merges both occurrences into one 1h bucket keyed at the first
+    01:00 EDT instant (05:00 UTC)."""
+    frame = _minute_frame(_utc(2025, 11, 2, 5, 30), _utc(2025, 11, 2, 6, 30), interval="1h")
+    # 05:30 UTC = 01:30 EDT (first pass); 06:30 UTC = 01:30 EST (second pass)
+    groups = _apply(bucket_key_expr("1h", SESSIONS[InstrumentType.FUTURES_CME]), frame)
+
+    assert groups.n_unique() == 1
+    assert groups.unique().to_list() == [_utc(2025, 11, 2, 5, 0)]  # 01:00 EDT, earliest
+
+
+# ---------------------------------------------------------------------------
 # (c) unknown timeframe raises ValueError
 # ---------------------------------------------------------------------------
 

--- a/thestrat/__init__.py
+++ b/thestrat/__init__.py
@@ -8,7 +8,7 @@ Public API:
 
 from importlib.metadata import PackageNotFoundError, version
 
-from thestrat.aggregator import EQUITY_OFFSET_MINUTES, TimeframeAggregator
+from thestrat.aggregator import EQUITY_OFFSET_MINUTES, TimeframeAggregator, bucket_key_expr
 from thestrat.classifier import (
     SHAPE_BODY_ZONE,
     classify_bar,
@@ -34,6 +34,7 @@ except PackageNotFoundError:
 
 __all__ = [
     "TimeframeAggregator",
+    "bucket_key_expr",
     "EQUITY_OFFSET_MINUTES",
     "classify_bar",
     "classify_bars_df",

--- a/thestrat/aggregator.py
+++ b/thestrat/aggregator.py
@@ -56,6 +56,23 @@ def bucket_key_expr(timeframe: str, session: Session | None) -> pl.Expr:
 
     Returns:
         A `pl.Expr` over a `timestamp` column producing the bucket key.
+        If a `session` is provided, the `timestamp` column must be
+        timezone-aware — the expression calls `dt.convert_time_zone`, which
+        raises on a naive column. (`TimeframeAggregator.aggregate` coerces
+        naive timestamps to UTC before applying it; consumers using this
+        expression directly must do the same.)
+
+    DST note:
+        Session-aware bucketing is wall-clock ("calendar") bucketing in the
+        session timezone. Anchor arithmetic is performed on naive local
+        timestamps so a DST transition inside a bucket does not shift its
+        boundary (subtracting a physical duration from a tz-aware column
+        would misanchor buckets that span a transition — e.g. the CME Globex
+        Sunday session on a US spring-forward date). Consequences: on a
+        fall-back date the repeated local hour merges into one wall-clock
+        bucket, and a bucket key that would land inside a spring-forward gap
+        (a non-existent local time) is shifted forward one hour to the first
+        instant that exists — the true start of that bucket.
 
     Raises:
         ValueError: if `timeframe` is not a supported aggregation timeframe.
@@ -73,8 +90,21 @@ def bucket_key_expr(timeframe: str, session: Session | None) -> pl.Expr:
     # Session-aware path (preferred): aligns hour+ buckets to the session anchor.
     if session is not None:
         offset = pl.duration(minutes=session.anchor_minutes)
-        ts_local = ts.dt.convert_time_zone(session.timezone)
-        return ((ts_local - offset).dt.truncate(unit) + offset).dt.convert_time_zone("UTC")
+        # Wall-clock arithmetic: strip the timezone so the anchor offset and
+        # truncation operate on local calendar time. Physical-duration
+        # arithmetic on a tz-aware column shifts by exact physical time and
+        # misanchors any bucket spanning a DST transition (see DST note).
+        ts_naive = ts.dt.convert_time_zone(session.timezone).dt.replace_time_zone(None)
+        key_naive = (ts_naive - offset).dt.truncate(unit) + offset
+        # Re-attach the timezone. `ambiguous="earliest"`: a key in a repeated
+        # (fall-back) hour is the first occurrence — the bucket's true start.
+        # `non_existent="null"` + fill: a key inside a spring-forward gap is
+        # shifted forward one hour to the first local instant that exists.
+        key = key_naive.dt.replace_time_zone(session.timezone, ambiguous="earliest", non_existent="null")
+        gap_shifted = (key_naive + pl.duration(hours=1)).dt.replace_time_zone(
+            session.timezone, ambiguous="earliest", non_existent="null"
+        )
+        return key.fill_null(gap_shifted).dt.convert_time_zone("UTC")
 
     # No session: UTC-anchored truncation (legacy behavior).
     return ts.dt.truncate(unit)

--- a/thestrat/aggregator.py
+++ b/thestrat/aggregator.py
@@ -18,7 +18,6 @@ from thestrat.sessions import SESSIONS, InstrumentType, Session
 EQUITY_OFFSET_MINUTES = 30
 
 _HOUR_BASED = {"1h", "4h", "6h", "12h"}
-_DAILY_PLUS = {"1d", "1w", "1m", "1q", "1y"}
 _TRUNC_UNIT = {
     "1min": "1m",
     "5min": "5m",
@@ -34,6 +33,51 @@ _TRUNC_UNIT = {
     "1q": "1q",
     "1y": "1y",
 }
+
+
+def bucket_key_expr(timeframe: str, session: Session | None) -> pl.Expr:
+    """Return the Polars expression that maps each timestamp to its bucket key.
+
+    The "bucket key" is the value thestrat groups on to aggregate 1-minute bars
+    into a higher timeframe — internally the aggregator calls it `_group`. This
+    is the supported public form of that grouping logic, so consumers can reuse
+    it instead of re-implementing the session-anchored bucketing.
+
+    Args:
+        timeframe: Target timeframe ("1min", "5min", "15min", "30min", "1h",
+            "4h", "6h", "12h", "1d", "1w", "1m", "1q", "1y").
+        session: Session preset (timezone + anchor minutes). When given, all
+            hour-and-above timeframes are aligned to this anchor (e.g.
+            `SESSIONS[EQUITY_US]` anchors hourly buckets to 09:30 ET and daily+
+            to the 09:30 ET session start). When None, hour-and-above buckets
+            fall back to plain UTC-anchored truncation. Sub-hour timeframes
+            (1min, 5min, 15min, 30min) are always plain truncation regardless
+            of `session`.
+
+    Returns:
+        A `pl.Expr` over a `timestamp` column producing the bucket key.
+
+    Raises:
+        ValueError: if `timeframe` is not a supported aggregation timeframe.
+    """
+    if timeframe not in _TRUNC_UNIT:
+        raise ValueError(f"Unsupported aggregation timeframe: {timeframe}")
+
+    ts = pl.col("timestamp")
+    unit = _TRUNC_UNIT[timeframe]
+
+    # Sub-hour: simple truncation, never session-aligned.
+    if timeframe in ("1min", "5min", "15min", "30min"):
+        return ts.dt.truncate(unit)
+
+    # Session-aware path (preferred): aligns hour+ buckets to the session anchor.
+    if session is not None:
+        offset = pl.duration(minutes=session.anchor_minutes)
+        ts_local = ts.dt.convert_time_zone(session.timezone)
+        return ((ts_local - offset).dt.truncate(unit) + offset).dt.convert_time_zone("UTC")
+
+    # No session: UTC-anchored truncation (legacy behavior).
+    return ts.dt.truncate(unit)
 
 
 class TimeframeAggregator:
@@ -120,26 +164,19 @@ class TimeframeAggregator:
         equity_offset: bool,
         session: Session | None,
     ) -> pl.Expr:
-        """Return a Polars expression that groups timestamps by timeframe."""
-        ts = pl.col("timestamp")
-        unit = _TRUNC_UNIT[timeframe]
+        """Return a Polars expression that groups timestamps by timeframe.
 
-        # Sub-hour: simple truncation, never session-aligned.
-        if timeframe in ("1min", "5min", "15min", "30min"):
-            return ts.dt.truncate(unit)
+        Delegates to the public `bucket_key_expr` for the session-aware and
+        no-session paths. The only branch retained here is the legacy
+        `equity_offset` shortcut (hour-based only, no session) preserved for
+        backward compatibility of `aggregate(..., equity_offset=True)`.
+        """
+        # Legacy `equity_offset` path: 30-min shift for hour-based only, and
+        # only when no session is supplied (a session takes precedence).
+        if session is None and equity_offset and timeframe in _HOUR_BASED:
+            ts = pl.col("timestamp")
+            unit = _TRUNC_UNIT[timeframe]
+            offset = pl.duration(minutes=EQUITY_OFFSET_MINUTES)
+            return (ts - offset).dt.truncate(unit) + offset
 
-        # Session-aware path (preferred): aligns hour+ buckets to session anchor.
-        if session is not None and (timeframe in _HOUR_BASED or timeframe in _DAILY_PLUS):
-            offset = pl.duration(minutes=session.anchor_minutes)
-            ts_local = ts.dt.convert_time_zone(session.timezone)
-            return ((ts_local - offset).dt.truncate(unit) + offset).dt.convert_time_zone("UTC")
-
-        # Legacy `equity_offset` path: 30-min shift for hour-based only.
-        if timeframe in _HOUR_BASED:
-            if equity_offset:
-                offset = pl.duration(minutes=EQUITY_OFFSET_MINUTES)
-                return (ts - offset).dt.truncate(unit) + offset
-            return ts.dt.truncate(unit)
-
-        # Daily+ without session: UTC-anchored truncation (legacy behavior).
-        return ts.dt.truncate(unit)
+        return bucket_key_expr(timeframe, session)

--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ wheels = [
 
 [[package]]
 name = "thestrat"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "polars", extra = ["timezone"] },


### PR DESCRIPTION
Closes #64

## What

Promotes the private `TimeframeAggregator._group_expression` to a public module-level free function:

```python
def bucket_key_expr(timeframe: str, session: Session | None) -> pl.Expr
```

- Exported from `thestrat/__init__.py` (`__all__`).
- The "bucket key" is the value the aggregator groups on internally (its `_group` column) — the docstring pins that vocabulary.
- Raises `ValueError` on an unknown timeframe.
- **Drops** the legacy `equity_offset: bool` flag from the public signature — session presence carries that meaning now (`session=SESSIONS[EQUITY_US]`).
- Version bumped 1.1.0 → 1.2.0 (new non-breaking public API = semver minor), matching the repo's in-commit version convention.

## Why

Downstream **StratBacktester** re-implements this exact expression in `bar_stitcher.py` (`_bucket_key_expr`) with a documented lockstep-sync landmine. Making it public lets the consumer import it instead of mirroring it (Task 0.1 of the StratBacktester US-equities data-layer plan; downstream pins the resulting tag before deleting its mirror).

## No behavior change

`_group_expression` is retained as a thin private wrapper: it keeps only the legacy `equity_offset` shortcut (backward compat for `aggregate(..., equity_offset=True)`, which remains tested) and delegates every other path — session-aware, no-session, sub-hour — to `bucket_key_expr`. The now-orphaned `_DAILY_PLUS` constant is removed.

## Tests

New `tests/test_bucket_key_expr.py`:
- EQUITY_US hourly buckets anchor 09:30/10:30/…/15:30 ET over an RTH minute frame (7 buckets incl. the 15:30 stub); daily anchors 09:30 ET.
- FUTURES_CME output matches the pre-refactor `_group_expression` row-for-row across 1h/4h/1d/1w (parity guard).
- `session=None` == plain UTC truncation; sub-hour timeframes ignore `session`.
- Unknown timeframe raises `ValueError` (parametrized over `None` + EQUITY_US).
- Importable from the package top level.

Full suite: **102 passed** (94 baseline + 8 new); `aggregator.py` at 100% coverage. `ruff check` + `ruff format --check` + `pyright` all clean locally (CI mirror).

## Not in this PR

Merge + `v1.2.0` tag happen after review; the downstream pin (StratBacktester Task 0.2) and the `bar_stitcher` swap (Task 0.3) follow the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-aware time bucketing for supported hourly, daily, and larger timeframes, aligned to each session’s anchor minutes.
  * When no session is provided, grouping uses legacy UTC truncation (including sub-hour intervals).
  * Exposed `bucket_key_expr` via the package’s public API.
* **Tests**
  * Expanded behavioral coverage, including equity RTH anchoring and futures daily bucketing, with multiple US DST spring-forward/fall-back scenarios.
* **Chores**
  * Updated package version to **1.2.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->