### PR TITLE
ci: sync canonical code-review CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,57 +1,13 @@
+# Canonical pre-commit hooks, seeded by the deploy-ci plugin.
+# Mirrors the server-side `lint` job in ci.yml (ruff check + ruff format) so
+# mechanical lint/format issues are fixed locally at commit time instead of
+# failing CI. CI remains the read-only enforcement gate.
+#
+# Install once per clone:  pre-commit install
 repos:
-  # Ruff - Python linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.15.14
     hooks:
-      - id: ruff
-        name: "🐍 Python · Lint with Ruff"
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
-        name: "🐍 Python · Format with Ruff"
-
-  # Pyright - Python type checking (Pylance equivalent) - Disabled during setup
-  # - repo: https://github.com/RobertCraigie/pyright-python
-  #   rev: v1.1.405
-  #   hooks:
-  #     - id: pyright
-  #       name: "🐍 Python · Type check with Pyright"
-  #       additional_dependencies:
-  #         - polars[timezone]
-  #         - pandas
-  #         - numpy
-  #         - pytz
-  #         - pyarrow
-  #         - pydantic
-
-  # Standard pre-commit hooks
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-      - id: trailing-whitespace
-        name: "🧹 Text · Remove trailing whitespace"
-      - id: end-of-file-fixer
-        name: "🧹 Text · Fix end of files"
-      - id: check-yaml
-        name: "📋 YAML · Validate syntax"
-        exclude: ^\.github/workflows/auto-close-issues\.yml$
-      - id: check-added-large-files
-        name: "📁 Files · Check for large files"
-        args: [--maxkb=500]
-      - id: check-merge-conflict
-        name: "🔀 Git · Check for merge conflicts"
-      - id: check-case-conflict
-        name: "📁 Files · Check for case conflicts"
-      - id: check-toml
-        name: "📋 TOML · Validate syntax"
-
-  # Local hooks for project-specific checks
-  - repo: local
-    hooks:
-      - id: pytest-check
-        name: "🧪 Python · Run pytest (quick)"
-        entry: uv run pytest
-        language: system
-        pass_filenames: false
-        args: [--tb=short, -x, -q]
-        types: [python]
-        stages: [pre-push]  # Only run on pre-push, not every commit

--- a/README.md
+++ b/README.md
@@ -77,11 +77,16 @@ uv sync --extra test --extra dev
 import polars as pl
 from thestrat import TimeframeAggregator
 
-bars = pl.DataFrame({
-    "timestamp": [...],
-    "open": [...], "high": [...], "low": [...], "close": [...],
-    "volume": [...],
-})
+bars = pl.DataFrame(
+    {
+        "timestamp": [...],
+        "open": [...],
+        "high": [...],
+        "low": [...],
+        "close": [...],
+        "volume": [...],
+    }
+)
 
 agg = TimeframeAggregator()
 hourly = agg.aggregate(bars, "1h")
@@ -113,13 +118,20 @@ classified = classify_bars_multi_symbol(bars)
 ```python
 from thestrat import classify_bar, classify_color, classify_scenario
 
-color = classify_color(open_price=100.0, close_price=101.0)         # Color.GREEN
-scenario = classify_scenario(curr_high=105, curr_low=95,
-                             prev_high=104, prev_low=96)            # Scenario.TWO_UP
+color = classify_color(open_price=100.0, close_price=101.0)  # Color.GREEN
+scenario = classify_scenario(curr_high=105, curr_low=95, prev_high=104, prev_low=96)  # Scenario.TWO_UP
 
 bar = classify_bar(
-    bar={"symbol": "ESM6", "timestamp": ts, "timeframe": "1d",
-         "open": 100, "high": 105, "low": 95, "close": 103, "volume": 1000},
+    bar={
+        "symbol": "ESM6",
+        "timestamp": ts,
+        "timeframe": "1d",
+        "open": 100,
+        "high": 105,
+        "low": 95,
+        "close": 103,
+        "volume": 1000,
+    },
     prior=prior_bar_dict_or_None,
 )
 ```


### PR DESCRIPTION
Sync canonical code-review CI from the deploy-ci plugin.

Brings deterministic CI, the autonomous Review Coordinator loop, and local pre-commit checks up to the current canonical bundle. The coordinator may enable auto-merge only after a clean current-SHA review; GitHub still waits for every required deterministic check.

Run `pre-commit install` once per clone after merge.

- Codex