### PR TITLE
ci: sync canonical code-review CI

### DIFF
--- a/.github/workflows/agent-review-loop.yml
+++ b/.github/workflows/agent-review-loop.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           repository: jlixfeld/review-automation
-          ref: ac36c092158964de90228356070f1dc7ae084509
+          ref: 71d6c54360c3e39cbd71447617596372d44decf5
           path: review-automation
           persist-credentials: false
 


### PR DESCRIPTION
Sync canonical code-review CI from the deploy-ci plugin.

Brings deterministic CI, the autonomous Review Coordinator loop, and local pre-commit checks up to the current canonical bundle. The coordinator may enable auto-merge only after a clean current-SHA review; GitHub still waits for every required deterministic check.

Run `pre-commit install` once per clone after merge.

- Codex